### PR TITLE
Solves #34: Bump PHP to min 8.3

### DIFF
--- a/.github/workflows/on-pull-request.yml
+++ b/.github/workflows/on-pull-request.yml
@@ -12,13 +12,8 @@ jobs:
       max-parallel: 3
       matrix:
         php:
-          - 7.2
-          - 7.3
-          - 7.4
-          - 8.0
-          - 8.1
-          - 8.2
           - 8.3
+          - 8.4
         composer: 
           - 2  
     name: Test - php:${{ matrix.php }}; composer:${{ matrix.composer }}

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "silinternational/php-env": "^2.1",
-        "php": ">=7.2"
+        "silinternational/php-env": "^3.3",
+        "php": ">=8.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^8",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -20,14 +20,6 @@
         timeoutForLargeTests="60"
         verbose="false">
 
-    <coverage includeUncoveredFiles="true">
-        <include>
-            <directory>src</directory>
-        </include>
-        <report>
-            <clover outputFile="log/clover.xml"/>
-        </report>
-    </coverage>
     <testsuites>
         <testsuite name="All">
             <directory suffix="Test.php">tests/</directory>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated supported PHP versions to 8.3 and 8.4 in testing workflows.
  - Increased minimum required PHP version to 8.3 and updated a package dependency to a newer version.
- **Tests**
  - Removed code coverage reporting configuration from the test suite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->